### PR TITLE
fix: link to repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Eyevinn/whpp-clientgit"
+    "url": "git+https://github.com/Eyevinn/whpp-client"
   },
   "devDependencies": {
     "microbundle": "^0.15.0",


### PR DESCRIPTION
The link back here from https://www.npmjs.com/package/@eyevinn/whpp-client is broken now.